### PR TITLE
過去割り当てられたRequestに対するCompletedイベントが来た際にエラーにせずに許容する

### DIFF
--- a/bench/benchmarker/scenario/worldclient/worldclient.go
+++ b/bench/benchmarker/scenario/worldclient/worldclient.go
@@ -372,7 +372,9 @@ func (c *WorldClient) ConnectChairNotificationStream(ctx *world.Context, chair *
 				case api.RequestStatusARRIVED:
 					// event = &world.ChairNotificationEventArrived{}
 				case api.RequestStatusCOMPLETED:
-					event = &world.ChairNotificationEventCompleted{}
+					event = &world.ChairNotificationEventCompleted{
+						ServerRequestID: receivedRequest.RequestID,
+					}
 				case api.RequestStatusCANCELED:
 					// event = &world.ChairNotificationEventCanceled{}
 				}

--- a/bench/benchmarker/world/notification.go
+++ b/bench/benchmarker/world/notification.go
@@ -15,6 +15,8 @@ type ChairNotificationEventMatched struct {
 }
 
 type ChairNotificationEventCompleted struct {
+	ServerRequestID string
+
 	unimplementedNotificationEvent
 }
 

--- a/bench/benchmarker/world/world_test.go
+++ b/bench/benchmarker/world/world_test.go
@@ -75,7 +75,7 @@ func (s *FastServerStub) SendDepart(ctx *Context, req *Request) error {
 func (s *FastServerStub) SendEvaluation(ctx *Context, req *Request) error {
 	time.Sleep(s.latency)
 	if f, ok := s.chairNotificationReceiverMap.Get(req.Chair.ServerID); ok {
-		go f(&ChairNotificationEventCompleted{})
+		go f(&ChairNotificationEventCompleted{ServerRequestID: req.ServerID})
 	}
 	return nil
 }


### PR DESCRIPTION
### 主な変更内容
1. **過去のリクエスト履歴の考慮**
   - 過去に割り当てられていたリクエストに対して `COMPLETED` イベントが通知された場合、エラーを発生させずに無視する処理を追加しました。

2. **`RequestHistory` の導入**
   - `Chair` 構造体に `RequestHistory` フィールドが追加され、椅子が以前に引き受けたリクエストの履歴を記録するようになりました。

3. **`COMPLETED` イベント処理の改善**
   - `Chair.HandleNotification` メソッドで、現在のリクエストが存在しない場合でも、履歴に基づいて過去のリクエストに関連する `COMPLETED` イベントであればエラーを発生させないように変更されました。

4. **テストコードの修正**
   - テストコードで `ChairNotificationEventCompleted` イベントにリクエストID (`ServerRequestID`) を含むように修正しました。

5. **その他の細かい変更**
   - `world/notification.go` に `ServerRequestID` フィールドを持つ `ChairNotificationEventCompleted` を追加。
   - 不必要なメソッド（`ChangeRequestStatus`）が削除され、コードが簡素化されました。

### 背景と目的
この変更は、以前に割り当てられていたリクエストに関連するイベント通知が来た場合に、それをエラーとせずに適切に扱うためのものです。これにより、システムのロバスト性が向上し、予期しないエラーが発生するのを防ぎます。
