### PR TITLE
1tickを30msに固定

### DIFF
--- a/bench/benchmarker/scenario/scenario.go
+++ b/bench/benchmarker/scenario/scenario.go
@@ -138,6 +138,7 @@ func (s *Scenario) Load(ctx context.Context, step *isucandar.BenchmarkStep) erro
 		u.State = world.UserStateActive
 	}
 
+	lastLogTime := time.Now()
 	for now := range world.ConvertHour(24 * 14) {
 		err := s.world.Tick(s.worldCtx)
 		if err != nil {
@@ -146,7 +147,8 @@ func (s *Scenario) Load(ctx context.Context, step *isucandar.BenchmarkStep) erro
 		}
 
 		if now%world.ConvertHour(1) == 0 {
-			s.contestantLogger.Info("tick", zap.Int("time", now/world.ConvertHour(1)))
+			s.contestantLogger.Info("tick", zap.Duration("since", time.Since(lastLogTime)), zap.Int("time", now/world.ConvertHour(1)))
+			lastLogTime = time.Now()
 		}
 	}
 

--- a/bench/benchmarker/world/world.go
+++ b/bench/benchmarker/world/world.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/yuta-otsubo/isucon-sutra/bench/internal/concurrent"
 	"github.com/yuta-otsubo/isucon-sutra/bench/internal/random"
 )
 
@@ -59,15 +58,13 @@ func NewWorld(tickTimeout time.Duration, completedRequestChan chan *Request) *Wo
 		RootRand:             random.NewLockedRand(rand.NewPCG(0, 0)),
 		CompletedRequestChan: completedRequestChan,
 		tickTimeout:          tickTimeout,
-		timeoutTicker:        time.NewTicker(1 * time.Hour),
+		timeoutTicker:        time.NewTicker(tickTimeout),
 		criticalErrorCh:      make(chan error),
 	}
 }
 
 func (w *World) Tick(ctx *Context) error {
 	var wg sync.WaitGroup
-
-	w.timeoutTicker.Reset(w.tickTimeout)
 
 	for _, c := range w.ChairDB.Iter() {
 		// 前のTickの処理が完了していない椅子は完了するまで新しい時間はスキップする
@@ -100,8 +97,8 @@ func (w *World) Tick(ctx *Context) error {
 	case err := <-w.criticalErrorCh:
 		// クリティカルエラーが発生
 		return err
-	case <-concurrent.WaitChan(&wg):
-		// タイムアウトする前に完了
+	// case <-concurrent.WaitChan(&wg):
+	// 	// タイムアウトする前に完了
 
 	case <-w.timeoutTicker.C:
 		timeoutChair := 0


### PR DESCRIPTION
**概要:**
この変更は、シミュレーションの計測やタイムアウト処理の挙動を改善するための修正を含みます。特に、「1tick」を30msに固定し、ログのタイミングとタイムアウト処理の挙動を細かく調整しています。

---

**主な変更点:**

1. **`bench/benchmarker/scenario/scenario.go`の変更:**
    - ログ出力の間隔を計測するために、新たに`lastLogTime`を導入。
    - ログ出力の際に、前回のログからの経過時間（`time.Since(lastLogTime)`）を記録するよう修正。
    - これにより、ログ出力の精度が高まり、パフォーマンス監視が改善されます。

2. **`bench/benchmarker/world/world.go`の変更:**
    - `tickTimeout`をベースにしたタイムアウト処理に変更。
        - 以前は固定1時間だったが、動的に設定可能な`tickTimeout`を使用することで柔軟性が向上。
    - 一部不要になったコード（例えば、`timeoutTicker.Reset`）を削除。
    - コメントアウトされたコードが含まれ、以前の同期処理の一部が無効化されています。

---

この変更は、システムのパフォーマンス向上と動作の一貫性を目的としたものです。