### PR TITLE
feat:時間の進みを2000倍にする

### DIFF
--- a/webapp/go/app_handlers.go
+++ b/webapp/go/app_handlers.go
@@ -38,7 +38,7 @@ func appPostRegister(w http.ResponseWriter, r *http.Request) {
 	}
 	accessToken := secureRandomStr(32)
 	_, err := db.Exec(
-		"INSERT INTO users (id, username, firstname, lastname, date_of_birth, access_token) VALUES (?, ?, ?, ?, ?, ?)",
+		"INSERT INTO users (id, username, firstname, lastname, date_of_birth, access_token, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, isu_now(), isu_now())",
 		userID, req.Username, req.FirstName, req.LastName, req.DateOfBirth, accessToken,
 	)
 	if err != nil {
@@ -114,8 +114,8 @@ func appPostRequests(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if _, err := tx.Exec(
-		`INSERT INTO ride_requests (id, user_id, status, pickup_latitude, pickup_longitude, destination_latitude, destination_longitude) 
-				  VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO ride_requests (id, user_id, status, pickup_latitude, pickup_longitude, destination_latitude, destination_longitude, requested_at, updated_at) 
+				  VALUES (?, ?, ?, ?, ?, ?, ?, isu_now(), isu_now())`,
 		requestID, user.ID, "MATCHING", req.PickupCoordinate.Latitude, req.PickupCoordinate.Longitude, req.DestinationCoordinate.Latitude, req.DestinationCoordinate.Longitude,
 	); err != nil {
 		respondError(w, http.StatusInternalServerError, err)
@@ -211,7 +211,7 @@ func appPostRequestEvaluate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	result, err := db.Exec(
-		`UPDATE ride_requests SET evaluation = ?, status = ? WHERE id = ?`,
+		`UPDATE ride_requests SET evaluation = ?, status = ?, updated_at = isu_now() WHERE id = ?`,
 		postAppEvaluateRequest.Evaluation, "COMPLETED", requestID)
 	if err != nil {
 		respondError(w, http.StatusInternalServerError, err)
@@ -356,7 +356,7 @@ func appPostInquiry(w http.ResponseWriter, r *http.Request) {
 	}
 
 	_, err := db.Exec(
-		`INSERT INTO inquiries (user_id, subject, body) VALUES (?, ?, ?)`,
+		`INSERT INTO inquiries (user_id, subject, body, created_at) VALUES (?, ?, ?, isu_now())`,
 		user.ID, req.Subject, req.Body,
 	)
 	if err != nil {

--- a/webapp/go/chair_handlers.go
+++ b/webapp/go/chair_handlers.go
@@ -41,7 +41,7 @@ func chairPostRegister(w http.ResponseWriter, r *http.Request) {
 
 	accessToken := secureRandomStr(32)
 	_, err := db.Exec(
-		"INSERT INTO chairs (id, username, firstname, lastname, date_of_birth, chair_model, chair_no, is_active, access_token) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+		"INSERT INTO chairs (id, username, firstname, lastname, date_of_birth, chair_model, chair_no, is_active, access_token, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, isu_now(), isu_now())",
 		chairID, req.Username, req.Firstname, req.Lastname, req.DateOfBirth, req.ChairModel, req.ChairNo, false, accessToken,
 	)
 	if err != nil {
@@ -78,7 +78,7 @@ func chairAuthMiddleware(next http.Handler) http.Handler {
 func chairPostActivate(w http.ResponseWriter, r *http.Request) {
 	chair := r.Context().Value("chair").(*Chair)
 
-	_, err := db.Exec("UPDATE chairs SET is_active = ? WHERE id = ?", true, chair.ID)
+	_, err := db.Exec("UPDATE chairs SET is_active = ?, updated_at = isu_now() WHERE id = ?", true, chair.ID)
 	if err != nil {
 		respondError(w, http.StatusInternalServerError, err)
 		return
@@ -90,7 +90,7 @@ func chairPostActivate(w http.ResponseWriter, r *http.Request) {
 func chairPostDeactivate(w http.ResponseWriter, r *http.Request) {
 	chair := r.Context().Value("chair").(*Chair)
 
-	_, err := db.Exec("UPDATE chairs SET is_active = ? WHERE id = ?", false, chair.ID)
+	_, err := db.Exec("UPDATE chairs SET is_active = ?, updated_at = isu_now() WHERE id = ?", false, chair.ID)
 	if err != nil {
 		respondError(w, http.StatusInternalServerError, err)
 		return
@@ -116,7 +116,7 @@ func chairPostCoordinate(w http.ResponseWriter, r *http.Request) {
 	defer tx.Rollback()
 	chairLocationID := ulid.Make().String()
 	if _, err := tx.Exec(
-		`INSERT INTO chair_locations (id, chair_id, latitude, longitude) VALUES (?, ?, ?, ?)`,
+		`INSERT INTO chair_locations (id, chair_id, latitude, longitude, created_at) VALUES (?, ?, ?, ?, isu_now())`,
 		chairLocationID, chair.ID, req.Latitude, req.Longitude,
 	); err != nil {
 		respondError(w, http.StatusInternalServerError, err)
@@ -131,14 +131,14 @@ func chairPostCoordinate(w http.ResponseWriter, r *http.Request) {
 		}
 	} else {
 		if req.Latitude == rideRequest.PickupLatitude && req.Longitude == rideRequest.PickupLongitude {
-			if _, err := tx.Exec("UPDATE ride_requests SET status = 'DISPATCHED' WHERE id = ? AND status = 'DISPATCHING'", rideRequest.ID); err != nil {
+			if _, err := tx.Exec("UPDATE ride_requests SET status = 'DISPATCHED', dispatched_at = isu_now(), updated_at = isu_now() WHERE id = ? AND status = 'DISPATCHING'", rideRequest.ID); err != nil {
 				respondError(w, http.StatusInternalServerError, err)
 				return
 			}
 		}
 
 		if req.Latitude == rideRequest.DestinationLatitude && req.Longitude == rideRequest.DestinationLongitude {
-			if _, err := tx.Exec("UPDATE ride_requests SET status = 'ARRIVED' WHERE id = ? AND status = 'CARRYING'", rideRequest.ID); err != nil {
+			if _, err := tx.Exec("UPDATE ride_requests SET status = 'ARRIVED', arrived_at = isu_now(), updated_at = isu_now() WHERE id = ? AND status = 'CARRYING'", rideRequest.ID); err != nil {
 				respondError(w, http.StatusInternalServerError, err)
 				return
 			}
@@ -189,7 +189,7 @@ func chairGetNotification(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		if _, err := tx.Exec("UPDATE ride_requests SET chair_id = ? WHERE id = ?", chair.ID, matchRequest.ID); err != nil {
+		if _, err := tx.Exec("UPDATE ride_requests SET chair_id = ?, matched_at = isu_now(), updated_at = isu_now() WHERE id = ?", chair.ID, matchRequest.ID); err != nil {
 			respondError(w, http.StatusInternalServerError, err)
 			return
 		}
@@ -270,7 +270,7 @@ func chairGetNotificationSSE(w http.ResponseWriter, r *http.Request) {
 						return err
 					}
 
-					if _, err := tx.Exec("UPDATE ride_requests SET chair_id = ? WHERE id = ?", chair.ID, matchRequest.ID); err != nil {
+					if _, err := tx.Exec("UPDATE ride_requests SET chair_id = ?, matched_at = isu_now(), updated_at = isu_now() WHERE id = ?", chair.ID, matchRequest.ID); err != nil {
 						return err
 					}
 
@@ -404,7 +404,7 @@ func chairPostRequestAccept(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, err := tx.Exec("UPDATE ride_requests SET status = ? WHERE id = ?", "DISPATCHING", requestID); err != nil {
+	if _, err := tx.Exec("UPDATE ride_requests SET status = ?, updated_at = isu_now() WHERE id = ?", "DISPATCHING", requestID); err != nil {
 		respondError(w, http.StatusInternalServerError, err)
 		return
 	}
@@ -443,7 +443,7 @@ func chairPostRequestDeny(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, err := tx.Exec("UPDATE ride_requests SET chair_id = NULL, status = 'MATCHING', matched_at = NULL WHERE id = ?", requestID); err != nil {
+	if _, err := tx.Exec("UPDATE ride_requests SET chair_id = NULL, status = 'MATCHING', matched_at = NULL, updated_at = isu_now() WHERE id = ?", requestID); err != nil {
 		respondError(w, http.StatusInternalServerError, err)
 		return
 	}
@@ -482,7 +482,7 @@ func chairPostRequestDepart(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, err = tx.Exec("UPDATE ride_requests SET status = ? WHERE id = ?", "CARRYING", requestID); err != nil {
+	if _, err = tx.Exec("UPDATE ride_requests SET status = ?, updated_at = isu_now() WHERE id = ?", "CARRYING", requestID); err != nil {
 		respondError(w, http.StatusInternalServerError, err)
 		return
 	}

--- a/webapp/sql/schema.sql
+++ b/webapp/sql/schema.sql
@@ -6,6 +6,29 @@ GRANT ALL ON isucon.* TO 'isucon'@'%';
 
 USE isucon;
 
+DELIMITER //
+CREATE FUNCTION ISU_NOW() RETURNS DATETIME(6)
+  READS SQL DATA
+BEGIN
+  DECLARE base_time DATETIME(6);
+  DECLARE time_elapsed_microseconds BIGINT;
+  DECLARE accelerated_time BIGINT;
+
+  -- 今日の0時を基準にする（マイクロ秒精度）
+  SET base_time = CURDATE() + INTERVAL 0 MICROSECOND;
+
+  -- 経過時間をマイクロ秒単位で計算する（現在時刻 - 今日の0時）
+  SET time_elapsed_microseconds = TIMESTAMPDIFF(MICROSECOND, base_time, NOW(6));
+
+  -- 2000倍に加速させる
+  SET accelerated_time = time_elapsed_microseconds * 2000;
+
+  -- 0時から加速した時間を加える（マイクロ秒単位）
+  RETURN base_time + INTERVAL accelerated_time MICROSECOND;
+END //
+DELIMITER ;
+
+
 create table chairs
 (
   id         varchar(26) not null comment '椅子ID',
@@ -17,19 +40,19 @@ create table chairs
   chair_no     varchar(30) not null comment 'ISUナンバー',
   is_active  tinyint(1)  not null comment '配椅子受付中かどうか',
   access_token varchar(255) not null comment 'アクセストークン',
-  created_at datetime(6)  not null comment '登録日時' default current_timestamp(6),
-  updated_at datetime(6)   not null comment '更新日時' default current_timestamp(6) on update current_timestamp(6),
+  created_at datetime(6)  not null comment '登録日時',
+  updated_at datetime(6)   not null comment '更新日時',
   primary key (id)
 )
   comment = '椅子情報テーブル';
 
 create table chair_locations
 (
-  id        varchar(26) not null,
-  chair_id  varchar(26) not null comment '椅子ID',
+  id         varchar(26)         not null,
+  chair_id   varchar(26) not null comment '椅子ID',
   latitude   integer    not null comment '経度',
   longitude  integer    not null comment '緯度',
-  updated_at datetime(6)   not null comment '更新日時' default current_timestamp(6) on update current_timestamp(6),
+  created_at datetime(6)   not null comment '登録日時',
   primary key (id),
   constraint chair_locations_chairs_id_fk
     foreign key (chair_id) references chairs (id)
@@ -45,8 +68,8 @@ create table users
   lastname   varchar(30) not null comment '本名(名字)',
   date_of_birth varchar(30)      not null comment '生年月日',
   access_token varchar(255) not null comment 'アクセストークン',
-  created_at datetime(6)   not null comment '登録日時' default current_timestamp(6),
-  updated_at datetime(6)   not null comment '更新日時' default current_timestamp(6) on update current_timestamp(6),
+  created_at datetime(6)   not null comment '登録日時',
+  updated_at datetime(6)   not null comment '更新日時',
   primary key (id),
   unique (username),
   unique (access_token)
@@ -59,7 +82,7 @@ create table inquiries
   user_id    varchar(26) not null comment 'ユーザーID',
   subject    text        not null comment '件名',
   body       text        not null comment '本文',
-  created_at datetime(6)   not null comment '問い合わせ日時' default current_timestamp(6),
+  created_at datetime(6)   not null comment '問い合わせ日時',
   primary key (id),
   constraint inquiries_users_id_fk
     foreign key (user_id) references users (id)
@@ -77,12 +100,12 @@ create table ride_requests
   destination_latitude  integer                                                                                         not null comment '目的地(経度)',
   destination_longitude integer                                                                                         not null comment '目的地(緯度)',
   evaluation            integer                                                                                            null comment '評価',
-  requested_at          datetime(6)                                                                                      not null comment '要求日時' default current_timestamp(6),
+  requested_at          datetime(6)                                                                                      not null comment '要求日時',
   matched_at            datetime(6)                                                                                      null comment '椅子割り当て完了日時',
   dispatched_at         datetime(6)                                                                                      null comment '配車到着日時',
   rode_at               datetime(6)                                                                                      null comment '乗車日時',
   arrived_at            datetime(6)                                                                                      null comment '目的地到着日時',
-  updated_at            datetime(6)                                                                                      not null comment '状態更新日時' default current_timestamp(6) on update current_timestamp(6),
+  updated_at            datetime(6)                                                                                      not null comment '状態更新日時',
   primary key (id),
   constraint ride_requests_chairs_id_fk
     foreign key (chair_id) references chairs (id),


### PR DESCRIPTION
このプルリクエストは、ISUCON14プロジェクトにおいて「時間の進みを2000倍に加速する」機能を実装するためのものです。具体的には、新しいSQL関数 `ISU_NOW()` を導入し、これを利用してデータベースのタイムスタンプフィールドを管理する設計変更を行っています。この変更により、アプリケーション全体で時間の進行が統一され、シミュレーション環境の効率性と信頼性が向上します。

### **変更が及ぼす影響と潜在的なリスク**

- **影響**: 
  - データベーススキーマに新しいタイムスタンプフィールドが追加され、既存のフィールドのデフォルト値が削除されました。
  - アプリケーションコードにおいて、タイムスタンプを操作する際に `ISU_NOW()` 関数を利用するように変更されています。
  - これにより、時間データの一貫性が向上し、シミュレーション速度を柔軟に制御できます。

- **潜在的なリスク**:
  - 新しい関数 `ISU_NOW()` の実装が正しく動作しない場合、時間関連のデータの正確性が損なわれる可能性があります。
  - デフォルト値の削除に伴い、古いコードやクエリが期待通りに動作しなくなる可能性があります。
  - テストケースが不足している場合、この変更により予期しないバグが発生するリスクがあります。
