### PR TITLE
setup-goのキャッシュを効かせる

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           go-version-file: 'bench/go.mod'
           cache-dependency-path: |
-            bench/go.sum
+            ./bench/go.sum
       - name: Install Task
         uses: arduino/setup-task@v2
       - name: Build bench
@@ -36,7 +36,7 @@ jobs:
         with:
           go-version-file: 'bench/go.mod'
           cache-dependency-path: |
-            bench/go.sum
+            ./bench/go.sum
       - name: Install Task
         uses: arduino/setup-task@v2
       - name: Run bench Test

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -19,6 +19,8 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'bench/go.mod'
+          cache-dependency-path: |
+            bench/go.sum
       - name: Install Task
         uses: arduino/setup-task@v2
       - name: Build bench
@@ -33,6 +35,8 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'bench/go.mod'
+          cache-dependency-path: |
+            bench/go.sum
       - name: Install Task
         uses: arduino/setup-task@v2
       - name: Run bench Test

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,9 @@ jobs:
             - uses: actions/checkout@v4
             - uses: actions/setup-go@v5
               with:
-                go-version: '1.23'
+                go-version-file: 'bench/go.mod'
+                cache-dependency-path: |
+                    bench/go.sum
             - name: Install Task
               uses: arduino/setup-task@v2
             - name: Build bench
@@ -40,4 +42,3 @@ jobs:
               if: ${{ always() }}
               run: |
                 sudo docker compose -f compose-go.yml down -v
-

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,7 +22,7 @@ jobs:
               with:
                 go-version-file: 'bench/go.mod'
                 cache-dependency-path: |
-                    bench/go.sum
+                    ./bench/go.sum
             - name: Install Task
               uses: arduino/setup-task@v2
             - name: Build bench


### PR DESCRIPTION
### **1. `.github/workflows/bench.yml`**
- **追加内容**
  - `cache-dependency-path` が新たに追加されました。
  - 以下の行が2箇所（19行目と33行目付近）に挿入されています。
    ```yaml
    cache-dependency-path: |
      ./bench/go.sum
    ```
  - これにより、依存関係のキャッシュを有効にし、ビルドプロセスのパフォーマンス向上が期待されます。

---

### **2. `.github/workflows/go.yml`**
- **変更内容**
  - `go-version` の指定方法が直接バージョン番号を記載する方法（例: `'1.23'`）から、`go-version-file` を使用する方法に変更されました。
    - 変更前: `go-version: '1.23'`
    - 変更後:
      ```yaml
      go-version-file: 'bench/go.mod'
      cache-dependency-path: |
        ./bench/go.sum
      ```
  - これにより、依存関係のキャッシュが有効化され、また `bench/go.mod` に基づいてGoのバージョンを設定するようになりました。
