### PR TITLE
notificationのbugfix

### DIFF
--- a/webapp/go/app_handlers.go
+++ b/webapp/go/app_handlers.go
@@ -274,6 +274,7 @@ func appGetNotification(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		respondError(w, http.StatusInternalServerError, err)
+		return
 	}
 
 	chair := &Chair{}

--- a/webapp/go/models.go
+++ b/webapp/go/models.go
@@ -39,6 +39,7 @@ type Chair struct {
 type RideRequest struct {
 	ID                   string         `db:"id"`
 	UserID               string         `db:"user_id"`
+	DriverID             string         `db:"driver_id"`
 	ChairID              sql.NullString `db:"chair_id"`
 	Status               string         `db:"status"`
 	PickupLatitude       int            `db:"pickup_latitude"`


### PR DESCRIPTION
- error missing destination name driver_id の解決
- respondError後のreturn付け