### PR TITLE
ベンチマーカーのアクセス先ホストを本番想定のものに変更

### DIFF
--- a/bench/cmd/run.go
+++ b/bench/cmd/run.go
@@ -36,7 +36,7 @@ var runCmd = &cobra.Command{
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// supervisorで起動された場合は、targetを上書きする
 		if benchrun.GetTargetAddress() != "" {
-			targetURL = "https://trial.isucon14.net"
+			targetURL = "https://xiv.isucon.net"
 			targetAddr = fmt.Sprintf("%s:%d", benchrun.GetTargetAddress(), 443)
 		}
 


### PR DESCRIPTION
<!-- Referrer URL -->
```
https://github.com/isucon/isucon14/pull/363
```

ドメインを取得して動作させるならこの変更の値などを変える必要がある